### PR TITLE
update-repos prints which repo errored

### DIFF
--- a/src/RepoTool/Git.hs
+++ b/src/RepoTool/Git.hs
@@ -8,6 +8,7 @@ module RepoTool.Git
   , gitPullRebase
   , gitRepoStatuses
   , gitResetChanges
+  , printRepoName
   , renderRepoHash
   , updateRepoGitHash
   , updateAllRepoGitHashes


### PR DESCRIPTION
This patch catches any excpetion in while executing `gitPullRebase`,
prints the name of the repo that throwed it, and re-throws the error.