### PR TITLE
gitPullRebase output includes unnecesary new lines

### DIFF
--- a/src/RepoTool/Git/PullRebase.hs
+++ b/src/RepoTool/Git/PullRebase.hs
@@ -14,11 +14,9 @@ gitPullRebase (RepoDirectory fpath) = do
   if null xs
     then printRepoNameOk fpath
     else do
-      putStrLn ""
       printRepoName fpath
       putStrLn ":"
       mapM_ (\ s -> putStrLn ("  " ++ s)) xs
-      putStrLn ""
 
 lineFilter :: String -> Bool
 lineFilter l


### PR DESCRIPTION
Now I can get:
```
cardano-repo-tool update-repos                                    
cardano-base: ok
cardano-byron-proxy: ok
cardano-crypto: ok
cardano-ledger: ok
cardano-ledger-specs: ok
cardano-node:
  First, rewinding head to replay your work on top of it...
  Fast-forwarded master to b9c17c39dcab94ae8a7e62d18616d1a4ad28ff22.
cardano-prelude: ok
cardano-shell: ok
cardano-sl-x509: ok
iohk-monitoring-framework: ok
ouroboros-network: ok
```

and

```
cardano-repo-tool update-repo -r cardano-node
cardano-node:
  First, rewinding head to replay your work on top of it...
  Fast-forwarded master to b9c17c39dcab94ae8a7e62d18616d1a4ad28ff22.
```