### PR TITLE
Adds build dependency nix-archive

### DIFF
--- a/nix/.stack.nix/cardano-repo-tool.nix
+++ b/nix/.stack.nix/cardano-repo-tool.nix
@@ -22,6 +22,7 @@
           (hsPkgs.containers)
           (hsPkgs.directory)
           (hsPkgs.filepath)
+          (hsPkgs.nix-archive)
           (hsPkgs.process)
           (hsPkgs.text)
           ];

--- a/nix/.stack.nix/default.nix
+++ b/nix/.stack.nix/default.nix
@@ -1,7 +1,10 @@
 {
   extras = hackage:
     {
-      packages = {} // { cardano-repo-tool = ./cardano-repo-tool.nix; };
+      packages = {} // {
+        cardano-repo-tool = ./cardano-repo-tool.nix;
+        nix-archive = ./nix-archive.nix;
+        };
       compiler.version = "8.6.5";
       compiler.nix-name = "ghc865";
       };

--- a/nix/.stack.nix/nix-archive.nix
+++ b/nix/.stack.nix/nix-archive.nix
@@ -1,0 +1,58 @@
+{ system, compiler, flags, pkgs, hsPkgs, pkgconfPkgs, ... }:
+  {
+    flags = {};
+    package = {
+      specVersion = "2.4";
+      identifier = { name = "nix-archive"; version = "0.1.0.0"; };
+      license = "Apache-2.0";
+      copyright = "(c) 2020 IOHK";
+      maintainer = "operations@iohk.io";
+      author = "IOHK Engineering Team";
+      homepage = "";
+      url = "";
+      synopsis = "A library and executable for manipulating Nix Archive files";
+      description = "";
+      buildType = "Simple";
+      };
+    components = {
+      "library" = {
+        depends = [
+          (hsPkgs.base)
+          (hsPkgs.attoparsec)
+          (hsPkgs.base16-bytestring)
+          (hsPkgs.base32-z-bytestring)
+          (hsPkgs.binary)
+          (hsPkgs.bytestring)
+          (hsPkgs.containers)
+          (hsPkgs.cryptonite)
+          (hsPkgs.directory)
+          (hsPkgs.filepath)
+          (hsPkgs.memory)
+          (hsPkgs.pretty-show)
+          (hsPkgs.process-extras)
+          (hsPkgs.quiet)
+          (hsPkgs.text)
+          (hsPkgs.transformers)
+          (hsPkgs.transformers-except)
+          ];
+        };
+      exes = {
+        "nar" = {
+          depends = [
+            (hsPkgs.base)
+            (hsPkgs.bytestring)
+            (hsPkgs.filepath)
+            (hsPkgs.nix-archive)
+            (hsPkgs.optparse-applicative)
+            (hsPkgs.text)
+            ];
+          };
+        };
+      };
+    } // {
+    src = (pkgs.lib).mkDefault (pkgs.fetchgit {
+      url = "https://github.com/input-output-hk/nix-archive";
+      rev = "6ec16124fa060818b2dbd4b6e99b0ce4906c59e6";
+      sha256 = "0waldaw2yz9hhdlk8f8gmd37z4cgl5p3i3v6np1h9ydz4jnbbfm1";
+      });
+    }


### PR DESCRIPTION
Recent build dependency `nix-archive` was not added to *Nix* tooling.