### PR TITLE
Remove cardano-haskell from the repo list

### DIFF
--- a/main/cardano-repo-tool.hs
+++ b/main/cardano-repo-tool.hs
@@ -194,7 +194,6 @@ repos =
     , "cardano-byron-proxy"
     , "cardano-db-sync"
     , "cardano-crypto"
-    , "cardano-haskell"
     , "cardano-ledger"
     , "cardano-ledger-specs"
     , "cardano-node"


### PR DESCRIPTION
'cardano-haskell' is meant to be the top level project.