### PR TITLE
Remove `cardano-ledger` from repos

### DIFF
--- a/main/cardano-repo-tool.hs
+++ b/main/cardano-repo-tool.hs
@@ -195,7 +195,6 @@ repos =
     , "cardano-byron-proxy"
     , "cardano-db-sync"
     , "cardano-crypto"
-    , "cardano-ledger"
     , "cardano-ledger-specs"
     , "cardano-node"
     , "cardano-prelude"
@@ -206,4 +205,3 @@ repos =
     , "iohk-monitoring-framework"
     , "ouroboros-network"
     ]
-


### PR DESCRIPTION
This repo is deprecated; packages hosted there have moved to `cardano-ledger-specs`.